### PR TITLE
fix: exclude reasoning messages from LLM context when reasoning is disabled or expired

### DIFF
--- a/src/features/Chat/services/ChatGeneration/LLMMessageContextService.test.ts
+++ b/src/features/Chat/services/ChatGeneration/LLMMessageContextService.test.ts
@@ -297,6 +297,36 @@ describe("LLMMessageContextService", () => {
   });
 
   describe("disabled reasoning context filtering", () => {
+    it("excludes all reasoning messages when reasoningEnabled is false", async () => {
+      ChatSettingsService.Get.mockResolvedValue({
+        ...createDefaultChatSettings(),
+        reasoningEnabled: false,
+      });
+      LLMChatProjection.GetMessages.mockReturnValue([
+        {
+          id: "reasoning-1",
+          type: "reasoning",
+          role: "assistant",
+          content: "[Reasoning]\nSome reasoning\n[End of Reasoning]",
+        },
+        { id: "msg-1", type: "message", role: "user", content: "First" },
+        {
+          id: "reasoning-2",
+          type: "reasoning",
+          role: "assistant",
+          content: "[Reasoning]\nMore reasoning\n[End of Reasoning]",
+        },
+        { id: "msg-2", type: "message", role: "assistant", content: "Second" },
+      ]);
+      const service = new LLMMessageContextService(testChatId);
+
+      const result = await service.buildGenerationRequestMessages(false);
+
+      expect(result.some((m) => m.type === "reasoning")).toBe(false);
+      expect(result.map((m) => m.id)).toContain("msg-1");
+      expect(result.map((m) => m.id)).toContain("msg-2");
+    });
+
     it("excludes reasoning after the configured number of newer regular messages", async () => {
       ChatSettingsService.Get.mockResolvedValue({
         ...createDefaultChatSettings(),

--- a/src/features/Chat/services/ChatGeneration/LLMMessageContextService.test.ts
+++ b/src/features/Chat/services/ChatGeneration/LLMMessageContextService.test.ts
@@ -41,6 +41,7 @@ describe("LLMMessageContextService", () => {
     LLMChatProjection = {
       GetMessages: vi.fn().mockReturnValue(createMockChatMessages()),
       SetPreviousChapterMessageBuffer: vi.fn(),
+      SetReasoningRetention: vi.fn(),
     } as unknown as Mocked<LLMChatProjection>;
 
     MemoriesService = {
@@ -296,103 +297,51 @@ describe("LLMMessageContextService", () => {
     });
   });
 
-  describe("disabled reasoning context filtering", () => {
-    it("excludes all reasoning messages when reasoningEnabled is false", async () => {
+  describe("reasoning retention configuration", () => {
+    it("sets reasoning retention to 0 when reasoningEnabled is false", async () => {
       ChatSettingsService.Get.mockResolvedValue({
         ...createDefaultChatSettings(),
         reasoningEnabled: false,
       });
-      LLMChatProjection.GetMessages.mockReturnValue([
-        {
-          id: "reasoning-1",
-          type: "reasoning",
-          role: "assistant",
-          content: "[Reasoning]\nSome reasoning\n[End of Reasoning]",
-        },
-        { id: "msg-1", type: "message", role: "user", content: "First" },
-        {
-          id: "reasoning-2",
-          type: "reasoning",
-          role: "assistant",
-          content: "[Reasoning]\nMore reasoning\n[End of Reasoning]",
-        },
-        { id: "msg-2", type: "message", role: "assistant", content: "Second" },
-      ]);
       const service = new LLMMessageContextService(testChatId);
 
-      const result = await service.buildGenerationRequestMessages(false);
+      await service.buildGenerationRequestMessages(false);
 
-      expect(result.some((m) => m.type === "reasoning")).toBe(false);
-      expect(result.map((m) => m.id)).toContain("msg-1");
-      expect(result.map((m) => m.id)).toContain("msg-2");
+      expect(LLMChatProjection.SetReasoningRetention).toHaveBeenCalledWith(0);
     });
 
-    it("excludes reasoning after the configured number of newer regular messages", async () => {
+    it("sets reasoning retention to configured value", async () => {
       ChatSettingsService.Get.mockResolvedValue({
         ...createDefaultChatSettings(),
         reasoningExpiresAfterMessages: 2,
       });
-      LLMChatProjection.GetMessages.mockReturnValue([
-        {
-          id: "reasoning-1",
-          type: "reasoning",
-          role: "assistant",
-          content: "[Reasoning]\nOld reasoning\n[End of Reasoning]",
-        },
-        { id: "msg-1", type: "message", role: "user", content: "First" },
-        { id: "msg-2", type: "message", role: "assistant", content: "Second" },
-      ]);
       const service = new LLMMessageContextService(testChatId);
 
-      const result = await service.buildGenerationRequestMessages(false);
+      await service.buildGenerationRequestMessages(false);
 
-      expect(result.some((m) => m.id === "reasoning-1")).toBe(false);
-      expect(result.map((m) => m.id)).toContain("msg-1");
-      expect(result.map((m) => m.id)).toContain("msg-2");
+      expect(LLMChatProjection.SetReasoningRetention).toHaveBeenCalledWith(2);
     });
 
-    it("keeps reasoning when expiration is disabled", async () => {
+    it("sets reasoning retention to null when expiration is disabled", async () => {
       ChatSettingsService.Get.mockResolvedValue({
         ...createDefaultChatSettings(),
         reasoningExpiresAfterMessages: null,
       });
-      LLMChatProjection.GetMessages.mockReturnValue([
-        {
-          id: "reasoning-1",
-          type: "reasoning",
-          role: "assistant",
-          content: "[Reasoning]\nPersistent reasoning\n[End of Reasoning]",
-        },
-        { id: "msg-1", type: "message", role: "user", content: "First" },
-        { id: "msg-2", type: "message", role: "assistant", content: "Second" },
-      ]);
       const service = new LLMMessageContextService(testChatId);
 
-      const result = await service.buildGenerationRequestMessages(false);
+      await service.buildGenerationRequestMessages(false);
 
-      expect(result.map((m) => m.id)).toContain("reasoning-1");
+      expect(LLMChatProjection.SetReasoningRetention).toHaveBeenCalledWith(
+        null,
+      );
     });
 
-    it("keeps reasoning before it reaches the configured message limit", async () => {
-      ChatSettingsService.Get.mockResolvedValue({
-        ...createDefaultChatSettings(),
-        reasoningExpiresAfterMessages: 3,
-      });
-      LLMChatProjection.GetMessages.mockReturnValue([
-        {
-          id: "reasoning-1",
-          type: "reasoning",
-          role: "assistant",
-          content: "[Reasoning]\nRecent reasoning\n[End of Reasoning]",
-        },
-        { id: "msg-1", type: "message", role: "user", content: "First" },
-        { id: "msg-2", type: "message", role: "assistant", content: "Second" },
-      ]);
+    it("uses default retention when no override configured", async () => {
       const service = new LLMMessageContextService(testChatId);
 
-      const result = await service.buildGenerationRequestMessages(false);
+      await service.buildGenerationRequestMessages(false);
 
-      expect(result.map((m) => m.id)).toContain("reasoning-1");
+      expect(LLMChatProjection.SetReasoningRetention).toHaveBeenCalledWith(4);
     });
   });
 

--- a/src/features/Chat/services/ChatGeneration/LLMMessageContextService.ts
+++ b/src/features/Chat/services/ChatGeneration/LLMMessageContextService.ts
@@ -153,24 +153,30 @@ export class LLMMessageContextService {
   }
 
   private getChatMessages(chatSettings: ChatSettings): LLMMessage[] {
-    const messages = d.LLMChatProjection(this.chatId).GetMessages();
-
-    if (chatSettings.reasoningEnabled === false) {
-      return this.excludeAllReasoningMessages(messages);
-    }
-
-    return this.excludeDisabledReasoningMessages(
-      messages,
-      chatSettings.reasoningExpiresAfterMessages ??
-        DEFAULT_REASONING_RETENTION_MESSAGES,
-    );
+    return d.LLMChatProjection(this.chatId).GetMessages();
   }
 
   private async applySystemContextSettings(): Promise<void> {
     const settings = await this.fetchSystemSettings();
-    d.LLMChatProjection(this.chatId).SetPreviousChapterMessageBuffer(
+    const chatSettings = await this.fetchChatSettings();
+    const projection = d.LLMChatProjection(this.chatId);
+
+    projection.SetPreviousChapterMessageBuffer(
       settings?.chapterCompressionSettings?.trailingChapterMessages ??
         DEFAULT_TRAILING_CHAPTER_MESSAGES,
+    );
+
+    projection.SetReasoningRetention(
+      this.getReasoningRetention(chatSettings),
+    );
+  }
+
+  private getReasoningRetention(chatSettings: ChatSettings): number | null {
+    if (chatSettings.reasoningEnabled === false) return 0;
+    if (chatSettings.reasoningExpiresAfterMessages === null) return null;
+    return (
+      chatSettings.reasoningExpiresAfterMessages ??
+      DEFAULT_REASONING_RETENTION_MESSAGES
     );
   }
 
@@ -366,30 +372,4 @@ export class LLMMessageContextService {
 
   private formatGuidanceMessage = (guidance: string): string =>
     `User guidance for the next response: ${guidance}`;
-
-  private excludeAllReasoningMessages(messages: LLMMessage[]): LLMMessage[] {
-    return messages.filter((message) => message.type !== "reasoning");
-  }
-
-  private excludeDisabledReasoningMessages(
-    messages: LLMMessage[],
-    expiresAfterMessages: number | null,
-  ): LLMMessage[] {
-    if (expiresAfterMessages === null) return messages;
-
-    return messages.filter(
-      (message, index) =>
-        message.type !== "reasoning" ||
-        this.countRegularMessagesAfter(messages, index) < expiresAfterMessages,
-    );
-  }
-
-  private countRegularMessagesAfter(
-    messages: LLMMessage[],
-    index: number,
-  ): number {
-    return messages
-      .slice(index + 1)
-      .filter((message) => message.type === "message").length;
-  }
 }

--- a/src/features/Chat/services/ChatGeneration/LLMMessageContextService.ts
+++ b/src/features/Chat/services/ChatGeneration/LLMMessageContextService.ts
@@ -153,8 +153,14 @@ export class LLMMessageContextService {
   }
 
   private getChatMessages(chatSettings: ChatSettings): LLMMessage[] {
+    const messages = d.LLMChatProjection(this.chatId).GetMessages();
+
+    if (chatSettings.reasoningEnabled === false) {
+      return this.excludeAllReasoningMessages(messages);
+    }
+
     return this.excludeDisabledReasoningMessages(
-      d.LLMChatProjection(this.chatId).GetMessages(),
+      messages,
       chatSettings.reasoningExpiresAfterMessages ??
         DEFAULT_REASONING_RETENTION_MESSAGES,
     );
@@ -360,6 +366,10 @@ export class LLMMessageContextService {
 
   private formatGuidanceMessage = (guidance: string): string =>
     `User guidance for the next response: ${guidance}`;
+
+  private excludeAllReasoningMessages(messages: LLMMessage[]): LLMMessage[] {
+    return messages.filter((message) => message.type !== "reasoning");
+  }
 
   private excludeDisabledReasoningMessages(
     messages: LLMMessage[],

--- a/src/services/CQRS/LLMChatProjection.ts
+++ b/src/services/CQRS/LLMChatProjection.ts
@@ -30,6 +30,7 @@ export const getLLMChatProjectionInstance = createInstanceCache(
 export class LLMChatProjection {
   private messages: MessageState[] = [];
   private numberOfPreviousChapterMessages: number = 6;
+  private reasoningRetentionMessages: number | null = null;
 
   private subscribers = new Set<() => void>();
 
@@ -131,6 +132,14 @@ export class LLMChatProjection {
     this.numberOfPreviousChapterMessages = Math.max(0, Math.round(count));
   }
 
+  /**
+   * Sets how many regular messages after a reasoning message before it expires.
+   * Pass `null` to keep all reasoning messages. Pass `0` to exclude all reasoning.
+   */
+  public SetReasoningRetention(messagesUntilExpiry: number | null): void {
+    this.reasoningRetentionMessages = messagesUntilExpiry;
+  }
+
   public GetMessages(): LLMMessage[] {
     const lastChapter = this.getLastChapter();
     let messages: MessageState[];
@@ -146,7 +155,7 @@ export class LLMChatProjection {
       }
     }
 
-    return this.excludeExpiredNotes(messages);
+    return this.excludeExpiredReasoning(this.excludeExpiredNotes(messages));
   }
 
   /**
@@ -508,6 +517,20 @@ export class LLMChatProjection {
         return true;
 
       return this.countMessagesAfterNote(msg.id) < msg.data.expiresAfterMessages;
+    });
+  }
+
+  private excludeExpiredReasoning(messages: MessageState[]): MessageState[] {
+    if (this.reasoningRetentionMessages === null) return messages;
+
+    return messages.filter((msg, index) => {
+      if (msg.type !== "reasoning") return true;
+      if (this.reasoningRetentionMessages === 0) return false;
+
+      const regularMessagesAfter = messages
+        .slice(index + 1)
+        .filter((m) => m.type === "message").length;
+      return regularMessagesAfter < this.reasoningRetentionMessages!;
     });
   }
 

--- a/src/services/CQRS/tests/LLMChatProjection.Reasoning.test.ts
+++ b/src/services/CQRS/tests/LLMChatProjection.Reasoning.test.ts
@@ -67,4 +67,54 @@ describe("LLMChatProjection - Reasoning Events", () => {
     };
     expect(reasoningMessage.hiddenByChapterId).toBe("chapter-1");
   });
+
+  describe("SetReasoningRetention filtering", () => {
+    it("excludes all reasoning when retention is set to 0", () => {
+      projection.process(ReasoningCreatedEventUtil.Create("First reasoning"));
+      projection.process(MessageCreatedEventUtil.Create("user", "Hello"));
+      projection.process(ReasoningCreatedEventUtil.Create("Second reasoning"));
+      projection.process(MessageCreatedEventUtil.Create("assistant", "Hi"));
+
+      projection.SetReasoningRetention(0);
+
+      const messages = projection.GetMessages();
+      expect(messages.every((m) => m.type !== "reasoning")).toBe(true);
+      expect(messages).toHaveLength(2);
+    });
+
+    it("excludes expired reasoning based on message count", () => {
+      projection.process(ReasoningCreatedEventUtil.Create("Old reasoning"));
+      projection.process(MessageCreatedEventUtil.Create("user", "First"));
+      projection.process(MessageCreatedEventUtil.Create("assistant", "Second"));
+      projection.process(MessageCreatedEventUtil.Create("user", "Third"));
+
+      projection.SetReasoningRetention(2);
+
+      const messages = projection.GetMessages();
+      expect(messages.every((m) => m.type !== "reasoning")).toBe(true);
+    });
+
+    it("keeps reasoning within retention window", () => {
+      projection.process(ReasoningCreatedEventUtil.Create("Recent reasoning"));
+      projection.process(MessageCreatedEventUtil.Create("user", "First"));
+
+      projection.SetReasoningRetention(2);
+
+      const messages = projection.GetMessages();
+      expect(messages.some((m) => m.type === "reasoning")).toBe(true);
+    });
+
+    it("keeps all reasoning when retention is null", () => {
+      projection.process(ReasoningCreatedEventUtil.Create("Old reasoning"));
+      projection.process(MessageCreatedEventUtil.Create("user", "First"));
+      projection.process(MessageCreatedEventUtil.Create("assistant", "Second"));
+      projection.process(MessageCreatedEventUtil.Create("user", "Third"));
+      projection.process(MessageCreatedEventUtil.Create("assistant", "Fourth"));
+
+      projection.SetReasoningRetention(null);
+
+      const messages = projection.GetMessages();
+      expect(messages.some((m) => m.type === "reasoning")).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
When `reasoningEnabled` is false in chat settings, all reasoning messages are now filtered out of the LLM request context. Additionally, reasoning expiration filtering has been moved into `LLMChatProjection.GetMessages()` via a new `SetReasoningRetention()` method, ensuring that ALL LLM callers (plans, discussions, characters, images) respect the reasoning disabled/expired setting—not just the text generation path.

Previously, disabling reasoning only prevented new reasoning generation but still included existing reasoning messages in subsequent LLM requests, and expiration filtering was only applied in the text generation context service.